### PR TITLE
Try again to disable the sandbox

### DIFF
--- a/mingw-w64-v8/PKGBUILD
+++ b/mingw-w64-v8/PKGBUILD
@@ -233,6 +233,8 @@ build() {
     v8_enable_temporal_support=false
     v8_enable_verify_heap=false
     v8_symbol_level=${_symbol}
+    v8_static_library=true
+    v8_enable_sandbox=false
     v8_use_external_startup_data=false
     chrome_pgo_phase=0
     clang_use_chrome_plugins=false


### PR DESCRIPTION
@raedrizqie would you have any guess why this fails to link on ucrt64 only when we disable the sandbox option? See https://github.com/r-windows/ucrt-libs/actions/runs/18111124377/job/51537417850?pr=36